### PR TITLE
Add "Load Tasks" and "Time Grunt"

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -2,9 +2,15 @@ module.exports = function (grunt) {
 
     'use strict';
 
+    // Load in all Grunt tasks
+    require('load-grunt-tasks')(grunt);
+
+    // Display time per task after running Grunt
+    require('time-grunt')(grunt);
+
     grunt.initConfig({
         pkg: grunt.file.readJSON('package.json'),
-		
+
         /**
          * Sass
          */
@@ -75,13 +81,6 @@ module.exports = function (grunt) {
         }
     });
 
-    // Load NPM Tasks
-    grunt.loadNpmTasks('grunt-contrib-sass');
-    grunt.loadNpmTasks('grunt-contrib-watch');
-    grunt.loadNpmTasks('grunt-autoprefixer');
-    grunt.loadNpmTasks('grunt-contrib-uglify');
-
     // Register Tasks
     grunt.registerTask('default', [ 'sass', 'autoprefixer', 'uglify' ]);
-
 };

--- a/package.json
+++ b/package.json
@@ -1,12 +1,14 @@
 {
-	"name": "bare-ninja",
-	"version": "0.0.1",
-	"description": "Base node dependencies",
-	"devDependencies": {
-		"grunt": "~0.4.1",
-		"grunt-contrib-sass": "~0.7.3",
-		"grunt-contrib-watch": "~0.5.1",
-		"grunt-autoprefixer": "~0.7.3",
-		"grunt-contrib-uglify": "~0.5.0"
-	}
+  "name": "bare-ninja",
+  "version": "0.0.1",
+  "description": "Base node dependencies",
+  "devDependencies": {
+    "grunt": "~0.4.1",
+    "grunt-autoprefixer": "~0.7.3",
+    "grunt-contrib-sass": "~0.7.3",
+    "grunt-contrib-uglify": "~0.5.0",
+    "grunt-contrib-watch": "~0.5.1",
+    "load-grunt-tasks": "^0.5.0",
+    "time-grunt": "^0.3.2"
+  }
 }


### PR DESCRIPTION
Just a couple modifications to improve the `Gruntfile.js`.

Load Tasks will glob all of the Grunt tasks together so you don't have to write each one out.

Time Grunt will display the time it took to run each task. Pretty handy to see where optimization needs to be in our task runner
