### PR TITLE
Adding defaults to breakpoints will allow the breakpoints set _settings ...

### DIFF
--- a/css/sass/global/_variables.scss
+++ b/css/sass/global/_variables.scss
@@ -1,8 +1,8 @@
 /********** Breakpoints **********/
 
-$small: 30em;
-$medium: 50em;
-$large: 64em;
+$small: 30em !default;
+$medium: 50em !default;
+$large: 64em !default;
 
 /********** Modal **********/
 

--- a/css/stylus/global/_variables.styl
+++ b/css/stylus/global/_variables.styl
@@ -1,8 +1,8 @@
 /********** Breakpoints **********/
 
-$small = 30em;
-$medium = 50em;
-$large = 64em;
+$small = 30em !default;
+$medium = 50em !default;
+$large = 64em !default;
 
 /********** Modal **********/
 


### PR DESCRIPTION
Adding defaults to breakpoints will allow breakpoints to be set in settings partial to override the defaults. Currently the variables partial overrides the breakpoints even if you have a settings partial imported.
