### PR TITLE
Removed protocol on third-party scripts

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,12 +6,12 @@
 
         <title>BareKit</title>
         
-        <link href="http://fonts.googleapis.com/css?family=Satisfy|Roboto+Condensed:400,300" rel="stylesheet" type="text/css">
+        <link href="//fonts.googleapis.com/css?family=Satisfy|Roboto+Condensed:400,300" rel="stylesheet" type="text/css">
         <link rel="stylesheet" href="css/style.css">
 
         <!--[if lt IE 9]>
-        <script src="http://cdnjs.cloudflare.com/ajax/libs/html5shiv/r29/html5.min.js"></script>
-        <script src="http://cdnjs.cloudflare.com/ajax/libs/respond.js/1.1.0/respond.min.js"></script>
+        <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/r29/html5.min.js"></script>
+        <script src="//cdnjs.cloudflare.com/ajax/libs/respond.js/1.1.0/respond.min.js"></script>
         <![endif]-->
     </head>
 


### PR DESCRIPTION
If I load the web site in https, so https://trevanhetzel.github.io/barekit/ the third-party font library is blocked due to being insecure.

> Mixed Content: The page at 'trevanhetzel.github.io/' was loaded over HTTPS, but requested an insecure stylesheet 'fonts.googleapis.com/css?family=Satisfy|Roboto+Condensed:400,300'. This request has been blocked; the content must be served over HTTPS.

This pull request makes those request protocoless so that it'll load fine in http and https.
