### PR TITLE
Allow for more flexible accordion description terms

### DIFF
--- a/src/modules/accordion.js
+++ b/src/modules/accordion.js
@@ -26,7 +26,6 @@ Accordion.prototype.init = function (el, options) {
 
 Accordion.prototype.onClick = function (e) {
   var $target = $(e.target);
-  var $dts = $('dt');
 
   //prevent default behaviour on non-absolute links
   if ($target.is('a')) {
@@ -37,7 +36,7 @@ Accordion.prototype.onClick = function (e) {
   }
 
   //find the dt parent node
-  while($target.length && $.inArray($target[0], $dts) === -1) {
+  while($target.length && !$target.is('dt')) {
     $target = $target.parent();
   }
 


### PR DESCRIPTION
Working with the accordion we realized it was very strict on using an anchor tag - with no children - as the direct child of the description term. We wanted to created a more complex description term that could handle children with images, titles, other divs, etc.

Hope you approve, thanks!
