### PR TITLE
Prevent list items from inside the dropdown nav from floating left

### DIFF
--- a/css/sass/module/_dropdown-nav.scss
+++ b/css/sass/module/_dropdown-nav.scss
@@ -14,6 +14,10 @@
 			list-style: none;
 			margin: 0;
 			padding: 0;
+
+			li {
+				float: none;
+			}
 		}
 
 		&:hover {

--- a/css/stylus/module/_dropdown-nav.styl
+++ b/css/stylus/module/_dropdown-nav.styl
@@ -14,6 +14,10 @@
 			list-style: none;
 			margin: 0;
 			padding: 0;
+
+			li {
+				float: none;
+			}
 		}
 
 		&:hover {


### PR DESCRIPTION
If you set the width of list inside the dropdown to be wider than the elements inside, the float left from the parent list causes the elements to squash onto the same line.
