### PR TITLE
Make grid available as extends and remove the need for presentational ma...

### DIFF
--- a/css/sass/module/_grid.scss
+++ b/css/sass/module/_grid.scss
@@ -1,6 +1,153 @@
 // Default
 @for $i from 1 through 12 {
 	// width
+	%df-#{$i} {
+		width: $grid-width * $i;
+	}
+
+	%df-#{$i}-half {
+		width: $grid-width * $i + ($grid-width / 2);
+	}
+
+	// offset
+	%df-offset-#{$i} {
+		margin-left: $grid-width * $i;
+	}
+
+	%df-offset-#{$i}-half {
+		margin-left: $grid-width * $i + ($grid-width / 2);
+	}
+}
+
+// Small
+@include breakpoint(small) {
+	@for $i from 1 through 12 {
+		// width
+		%sm-#{$i} {
+			width: $grid-width * $i;
+		}
+
+		%sm-#{$i}-half {
+			width: $grid-width * $i + ($grid-width / 2);
+		}
+
+		// offset
+		%sm-offset-#{$i} {
+			margin-left: $grid-width * $i;
+		}
+
+		%sm-offset-#{$i}-half {
+			margin-left: $grid-width * $i + ($grid-width / 2);
+		}
+	}
+}
+
+// Medium
+@include breakpoint(medium) {
+	@for $i from 1 through 12 {
+		// width
+		%md-#{$i} {
+			width: $grid-width * $i;
+		}
+
+		%md-#{$i}-half {
+			width: $grid-width * $i + ($grid-width / 2);
+		}
+
+		// offset
+		%md-offset-#{$i} {
+			margin-left: $grid-width * $i;
+		}
+
+		%md-offset-#{$i}-half {
+			margin-left: $grid-width * $i + ($grid-width / 2);
+		}
+	}
+}
+
+// Large
+@include breakpoint(large) {
+	@for $i from 1 through 12 {
+		// width
+		%lg-#{$i} {
+			width: $grid-width * $i;
+		}
+
+		%lg-#{$i}-half {
+			width: $grid-width * $i + ($grid-width / 2);
+		}
+
+		// offset
+		%lg-offset-#{$i} {
+			margin-left: $grid-width * $i;
+		}
+
+		%lg-offset-#{$i}-half {
+			margin-left: $grid-width * $i + ($grid-width / 2);
+		}
+	}
+}
+
+// 0 halves
+%sm-half {
+	width: $grid-width / 2;
+}
+
+%sm-offset-half {
+	width: $grid-width / 2;
+}
+
+@include breakpoint(medium) {
+	%md-half {
+		width: $grid-width / 2;
+	}
+
+	%md-offset-0 {
+		margin: 0;
+	}
+
+	%md-offset-half {
+		margin-left: $grid-width / 2;
+	}
+}
+
+@include breakpoint(large) {
+	%lg-half {
+		width: $grid-width / 2;
+	}
+
+	%lg-offset-0 {
+		margin-left: 0;
+	}
+
+	%lg-offset-half {
+		margin-left: $grid-width / 2;
+	}
+}
+
+// Box model
+%has-gutter {
+	float: left;
+	padding: 0 var($gutter, 20px) / 2;
+}
+
+%row {
+	@extend .clearfix;
+
+	%row {
+		%has-gutter {
+			padding: 0;
+		}
+	}
+}
+
+/*---------------------------------------------
+ Backwards Compatibility
+---------------------------------------------*/
+
+// Default
+@for $i from 1 through 12 {
+	// width
 	.df-#{$i} {
 		width: $grid-width * $i;
 	}


### PR DESCRIPTION
Make grid available as extends and remove the need for presentational markup.

```
.site-header {
    @extend %row;
}

.site-branding {
    @extend %sm-4;
}
```
